### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -31,7 +31,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
   - "dependencies (8)"
   - "dependencies (11)"
-  - "linkage-monitor"
   - "lint"
   - "clirr"
   - "units (8)"


### PR DESCRIPTION
Linkage Monitor is no longer needed, because the Libraries BOM synchronizes with Google Cloud BOM and the shared dependencies BOM https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137